### PR TITLE
TASK: Restrict the required jobqueue-common to <3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Implements concrete Queue for the beanstalkd work queue. Requires the packages flowpack/jobqueue-common and pda/pheanstalk package to be installed.",
     "license": "MIT",
     "require": {
-        "flowpack/jobqueue-common": "*",
+        "flowpack/jobqueue-common": "<3.0.0",
         "pda/pheanstalk": "3.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Unlike the other backend implementations, this one has no constraint to the version of the  jobqueue-common. In order to change the interface of the jobqueue-common package with a new major version - we need to set a mor restrictive package constraint.